### PR TITLE
ci: Add Slack notifications to prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,13 +1,13 @@
 name: Publish prerelease
 on:
   workflow_call:
-    inputs:
-      aws-role-to-assume:
+    secrets:
+      TERRAFORM_MODULES_ROLE_ARN:
         required: true
-        type: string
-      aws-region:
+      TERRAFORM_MODULES_REGION:
         required: true
-        type: string
+      TERRAFORM_MODULES_SLACK_URL:
+        required: false
 
 jobs:
   publish:
@@ -19,11 +19,33 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ inputs.aws-role-to-assume }}
-          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ secrets.TERRAFORM_MODULES_ROLE_ARN }}
+          aws-region: ${{ secrets.TERRAFORM_MODULES_REGION }}
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Mirror in S3
         run: make s3
+      - name: Prepare Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_SLACK_URL }}
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          echo version=$(git describe --tags --always | sed 's/^v//' ) >> $GITHUB_ENV
+          echo name=$(echo "$GITHUB_REPOSITORY" | sed 's/^.*terraform-observe-//') >> $GITHUB_ENV
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TERRAFORM_MODULES_SLACK_URL }}
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@v1.19.0
+        with:
+          payload: |
+            {
+              "namespace": "observeinc",
+              "name": "${{ env.name }}",
+              "system": "observe",
+              "version": "${{ env.version }}",
+              "repo": "${{ github.repository }}",
+              "commit_link": "https://github.com/${{ github.repository }}/tree/${{ github.sha }}"
+            }


### PR DESCRIPTION
Ports the changes from https://github.com/observeinc/terraform-observe-example/pull/12 upstream so that they can be more easily reused in other Terraform module repos.

Validated with https://github.com/observeinc/terraform-observe-example/actions/runs/2320479447 (which successfully produced a Slack notification and prerelease artifacts) and https://github.com/observeinc/terraform-observe-example/runs/6425912883 (which did not provide a Slack URL and successfully skipped the Slack notification steps while otherwise completing successfully).